### PR TITLE
Default shard filename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ rfd = "0.10"
 nokhwa = { version = "0.10", features = ["input-native"] }
 bardecoder = "0.4"
 base85 = "1.1"
+chrono = "0.4.11"

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use chrono::Local;
 
 use iced::{
     alignment::Horizontal,
@@ -153,8 +154,11 @@ impl Application for HyperbackedApp {
                 self.page = AppPage::BackupResults;
             }
             Message::SaveBackup(num) => {
+                let current_date = Local::now().format("%Y-%m-%d").to_string();
+                let default_filename = current_date + "_share_" + &num.to_string() + ".pdf";
                 let file = FileDialog::new()
                     .add_filter("PDF Files", &["pdf"])
+                    .set_file_name(default_filename.as_str())
                     .save_file();
                 if let Some(file) = file {
                     let backup = self.generated_backup.as_ref().unwrap();

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -156,10 +156,10 @@ impl Application for HyperbackedApp {
             Message::SaveBackup(num) => {
                 let current_date = Local::now().format("%Y-%m-%d").to_string();
                 let default_filename = if self.backup_type == BackupType::Standard {
-                    current_date + "_shard_1_of_1" + ".pdf"
+                    format!("{}_shard_1_of_1.pdf", current_date)
                 } else {
                     let total = self.backup_type.to_config().total_shards;
-                    current_date + "_shard_" + &num.to_string() + "_of_" + &total.to_string() + ".pdf"
+                    format!("{}_shard_{}_of_{}.pdf", current_date, &num, &total)
                 };
 
                 let file = FileDialog::new()

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -155,7 +155,13 @@ impl Application for HyperbackedApp {
             }
             Message::SaveBackup(num) => {
                 let current_date = Local::now().format("%Y-%m-%d").to_string();
-                let default_filename = current_date + "_share_" + &num.to_string() + ".pdf";
+                let default_filename = if self.backup_type == BackupType::Standard {
+                    current_date + "_shard_1_of_1" + ".pdf"
+                } else {
+                    let total = self.backup_type.to_config().total_shards;
+                    current_date + "_shard_" + &num.to_string() + "_of_" + &total.to_string() + ".pdf"
+                };
+
                 let file = FileDialog::new()
                     .add_filter("PDF Files", &["pdf"])
                     .set_file_name(default_filename.as_str())


### PR DESCRIPTION
I added a default file name for shard pdf files.
The format is `YYYY-MM-DD_shard_x_of_y.pdf` where x is the current shard and y is the shards. 